### PR TITLE
Algorithm Lucidity

### DIFF
--- a/include/paseto.h
+++ b/include/paseto.h
@@ -17,6 +17,26 @@ extern "C"{
 #define paseto_v2_PUBLIC_PUBLICKEYBYTES 32U
 #define paseto_v2_PUBLIC_SECRETKEYBYTES 64U
 
+enum KeyHeader {
+    V2_LOCAL = 4,
+    V2_PUBLIC = 5
+};
+
+typedef struct {
+    KeyHeader header;
+    uint8_t key_bytes[paseto_v2_LOCAL_KEYBYTES];
+} v2_local_key;
+
+typedef struct {
+    KeyHeader header;
+    uint8_t key_bytes[paseto_v2_PUBLIC_PUBLICKEYBYTES];
+} v2_public_pk;
+
+typedef struct {
+    KeyHeader header;
+    uint8_t key_bytes[paseto_v2_PUBLIC_SECRETKEYBYTES];
+} v2_public_sk;
+
 /**
  * Initialize the library. Must be called before using any functionality.
  */
@@ -32,14 +52,14 @@ void paseto_free(void *p);
  * Returns false on error and sets errno.
  */
 bool paseto_v2_local_load_key_hex(
-        uint8_t key[paseto_v2_LOCAL_KEYBYTES], const char *key_hex);
+        v2_local_key key, const char *key_hex);
 
 /**
  * Load a base64-url-encoded key (without padding).
  * Returns false on error and sets errno.
  */
 bool paseto_v2_local_load_key_base64(
-        uint8_t key[paseto_v2_LOCAL_KEYBYTES], const char *key_base64);
+        v2_local_key key, const char *key_base64);
 
 /**
  * Encrypt and encode `message` using `key`, attaching `footer` if it is not NULL.
@@ -49,7 +69,7 @@ bool paseto_v2_local_load_key_base64(
  */
 char *paseto_v2_local_encrypt(
         const uint8_t *message, size_t message_len,
-        const uint8_t key[paseto_v2_LOCAL_KEYBYTES],
+        const v2_local_key key,
         const uint8_t *footer, size_t footer_len);
 
 /**
@@ -66,14 +86,14 @@ char *paseto_v2_local_encrypt(
  */
 uint8_t *paseto_v2_local_decrypt(
         const char *encoded, size_t *message_len,
-        const uint8_t key[paseto_v2_LOCAL_KEYBYTES],
+        const v2_local_key key,
         uint8_t **footer, size_t *footer_len);
 
 /**
  * Load a hex-encoded key. Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_public_key_hex(
-        uint8_t key[paseto_v2_PUBLIC_PUBLICKEYBYTES],
+        v2_public_pk key,
         const char *key_hex);
 
 /**
@@ -81,7 +101,7 @@ bool paseto_v2_public_load_public_key_hex(
  * Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_public_key_base64(
-        uint8_t key[paseto_v2_PUBLIC_PUBLICKEYBYTES],
+        v2_public_pk key,
         const char *key_base64);
 
 /**
@@ -89,7 +109,7 @@ bool paseto_v2_public_load_public_key_base64(
  * Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_secret_key_hex(
-        uint8_t key[paseto_v2_PUBLIC_SECRETKEYBYTES],
+        v2_public_sk key,
         const char *key_hex);
 
 /**
@@ -97,7 +117,7 @@ bool paseto_v2_public_load_secret_key_hex(
  * Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_secret_key_base64(
-        uint8_t key[paseto_v2_PUBLIC_SECRETKEYBYTES],
+        v2_public_sk key,
         const char *key_base64);
 
 /**
@@ -108,7 +128,7 @@ bool paseto_v2_public_load_secret_key_base64(
  */
 char *paseto_v2_public_sign(
         const uint8_t *message, size_t message_len,
-        const uint8_t key[paseto_v2_PUBLIC_SECRETKEYBYTES],
+        const v2_public_sk key,
         const uint8_t *footer, size_t footer_len);
 
 /**
@@ -123,7 +143,7 @@ char *paseto_v2_public_sign(
  */
 uint8_t *paseto_v2_public_verify(
         const char *encoded, size_t *message_len,
-        const uint8_t key[paseto_v2_PUBLIC_PUBLICKEYBYTES],
+        const v2_public_pk key,
         uint8_t **footer, size_t *footer_len);
 
 

--- a/include/paseto.h
+++ b/include/paseto.h
@@ -17,25 +17,25 @@ extern "C"{
 #define paseto_v2_PUBLIC_PUBLICKEYBYTES 32U
 #define paseto_v2_PUBLIC_SECRETKEYBYTES 64U
 
-enum KeyHeader {
+enum paseto_key_header {
     V2_LOCAL = 4,
     V2_PUBLIC = 5
 };
 
-typedef struct {
-    KeyHeader header;
+struct paseto_v2_local_key {
+    paseto_key_header header;
     uint8_t key_bytes[paseto_v2_LOCAL_KEYBYTES];
-} v2_local_key;
+};
 
-typedef struct {
-    KeyHeader header;
+struct paseto_v2_local_pk {
+    paseto_key_header header;
     uint8_t key_bytes[paseto_v2_PUBLIC_PUBLICKEYBYTES];
-} v2_public_pk;
+};
 
-typedef struct {
-    KeyHeader header;
+struct paseto_v2_local_sk {
+    paseto_key_header header;
     uint8_t key_bytes[paseto_v2_PUBLIC_SECRETKEYBYTES];
-} v2_public_sk;
+};
 
 /**
  * Initialize the library. Must be called before using any functionality.
@@ -52,14 +52,14 @@ void paseto_free(void *p);
  * Returns false on error and sets errno.
  */
 bool paseto_v2_local_load_key_hex(
-        v2_local_key key, const char *key_hex);
+        struct paseto_v2_local_key *key, const char *key_hex);
 
 /**
  * Load a base64-url-encoded key (without padding).
  * Returns false on error and sets errno.
  */
 bool paseto_v2_local_load_key_base64(
-        v2_local_key key, const char *key_base64);
+        struct paseto_v2_local_key *key, const char *key_base64);
 
 /**
  * Encrypt and encode `message` using `key`, attaching `footer` if it is not NULL.
@@ -69,7 +69,7 @@ bool paseto_v2_local_load_key_base64(
  */
 char *paseto_v2_local_encrypt(
         const uint8_t *message, size_t message_len,
-        const v2_local_key key,
+        const struct paseto_v2_local_key *key,
         const uint8_t *footer, size_t footer_len);
 
 /**
@@ -86,14 +86,14 @@ char *paseto_v2_local_encrypt(
  */
 uint8_t *paseto_v2_local_decrypt(
         const char *encoded, size_t *message_len,
-        const v2_local_key key,
+        const struct paseto_v2_local_key *key,
         uint8_t **footer, size_t *footer_len);
 
 /**
  * Load a hex-encoded key. Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_public_key_hex(
-        v2_public_pk key,
+        struct paseto_v2_public_pk *key,
         const char *key_hex);
 
 /**
@@ -101,7 +101,7 @@ bool paseto_v2_public_load_public_key_hex(
  * Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_public_key_base64(
-        v2_public_pk key,
+        struct paseto_v2_public_pk *key,
         const char *key_base64);
 
 /**
@@ -109,7 +109,7 @@ bool paseto_v2_public_load_public_key_base64(
  * Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_secret_key_hex(
-        v2_public_sk key,
+        struct paseto_v2_public_sk *key,
         const char *key_hex);
 
 /**
@@ -117,7 +117,7 @@ bool paseto_v2_public_load_secret_key_hex(
  * Returns false on error and sets errno.
  */
 bool paseto_v2_public_load_secret_key_base64(
-        v2_public_sk key,
+        struct paseto_v2_public_sk *key,
         const char *key_base64);
 
 /**
@@ -128,7 +128,7 @@ bool paseto_v2_public_load_secret_key_base64(
  */
 char *paseto_v2_public_sign(
         const uint8_t *message, size_t message_len,
-        const v2_public_sk key,
+        const struct paseto_v2_public_sk *key,
         const uint8_t *footer, size_t footer_len);
 
 /**
@@ -143,7 +143,7 @@ char *paseto_v2_public_sign(
  */
 uint8_t *paseto_v2_public_verify(
         const char *encoded, size_t *message_len,
-        const v2_public_pk key,
+        const struct paseto_v2_public_pk *key,
         uint8_t **footer, size_t *footer_len);
 
 

--- a/src/paseto_v2_local.c
+++ b/src/paseto_v2_local.c
@@ -17,16 +17,18 @@ static const size_t mac_len = crypto_aead_xchacha20poly1305_ietf_ABYTES;
 
 
 bool paseto_v2_local_load_key_hex(
-        uint8_t key[paseto_v2_LOCAL_KEYBYTES],
+        v2_local_key key,
         const char *key_hex) {
-    return key_load_hex(key, paseto_v2_LOCAL_KEYBYTES, key_hex);
+        key.header = V2_LOCAL;
+    return key_load_hex(key.key_bytes, paseto_v2_LOCAL_KEYBYTES, key_hex);
 }
 
 
 bool paseto_v2_local_load_key_base64(
-        uint8_t key[paseto_v2_LOCAL_KEYBYTES],
+        v2_local_key key,
         const char *key_base64) {
-    return key_load_base64(key, paseto_v2_LOCAL_KEYBYTES, key_base64);
+        key.header = V2_LOCAL;
+    return key_load_base64(key.key_bytes, paseto_v2_LOCAL_KEYBYTES, key_base64);
 }
 
 
@@ -52,9 +54,13 @@ generate_nonce_fn generate_nonce = default_generate_nonce;
 
 char *paseto_v2_local_encrypt(
         const uint8_t *message, size_t message_len,
-        const uint8_t key[paseto_v2_LOCAL_KEYBYTES],
+        const v2_local_key key,
         const uint8_t *footer, size_t footer_len) {
     if (!message || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (key.header != V2_LOCAL) {
         errno = EINVAL;
         return NULL;
     }
@@ -89,7 +95,7 @@ char *paseto_v2_local_encrypt(
             ct, NULL,
             message, message_len,
             pa.base, pre_auth_len,
-            NULL, nonce, key);
+            NULL, nonce, key.key_bytes);
 
     free(pa.base);
 
@@ -134,9 +140,13 @@ char *paseto_v2_local_encrypt(
 
 uint8_t *paseto_v2_local_decrypt(
         const char *encoded, size_t *message_len,
-        const uint8_t key[paseto_v2_LOCAL_KEYBYTES],
+        const v2_local_key key,
         uint8_t **footer, size_t *footer_len) {
     if (!encoded || !message_len || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (key.header != V2_LOCAL) {
         errno = EINVAL;
         return NULL;
     }
@@ -233,7 +243,7 @@ uint8_t *paseto_v2_local_decrypt(
             NULL,
             ct, ct_len,
             pa.base, pre_auth_len,
-            nonce, key) != 0) {
+            nonce, key.key_bytes) != 0) {
         free(decoded);
         free(pa.base);
         free(message);

--- a/src/paseto_v2_local.c
+++ b/src/paseto_v2_local.c
@@ -17,18 +17,22 @@ static const size_t mac_len = crypto_aead_xchacha20poly1305_ietf_ABYTES;
 
 
 bool paseto_v2_local_load_key_hex(
-        v2_local_key key,
+        struct paseto_v2_local_key *key,
         const char *key_hex) {
-        key.header = V2_LOCAL;
-    return key_load_hex(key.key_bytes, paseto_v2_LOCAL_KEYBYTES, key_hex);
+        struct paseto_v2_local_key tmp;
+        *key = &tmp;
+        key->header = V2_LOCAL;
+    return key_load_hex(key->key_bytes, paseto_v2_LOCAL_KEYBYTES, key_hex);
 }
 
 
 bool paseto_v2_local_load_key_base64(
-        v2_local_key key,
+        struct paseto_v2_local_key *key,
         const char *key_base64) {
-        key.header = V2_LOCAL;
-    return key_load_base64(key.key_bytes, paseto_v2_LOCAL_KEYBYTES, key_base64);
+        struct paseto_v2_local_key tmp;
+        *key = &tmp;
+        key->header = V2_LOCAL;
+    return key_load_base64(key->key_bytes, paseto_v2_LOCAL_KEYBYTES, key_base64);
 }
 
 
@@ -54,13 +58,13 @@ generate_nonce_fn generate_nonce = default_generate_nonce;
 
 char *paseto_v2_local_encrypt(
         const uint8_t *message, size_t message_len,
-        const v2_local_key key,
+        const struct paseto_v2_local_key *key,
         const uint8_t *footer, size_t footer_len) {
     if (!message || !key) {
         errno = EINVAL;
         return NULL;
     }
-    if (key.header != V2_LOCAL) {
+    if (key->header != V2_LOCAL) {
         errno = EINVAL;
         return NULL;
     }
@@ -95,7 +99,7 @@ char *paseto_v2_local_encrypt(
             ct, NULL,
             message, message_len,
             pa.base, pre_auth_len,
-            NULL, nonce, key.key_bytes);
+            NULL, nonce, key->key_bytes);
 
     free(pa.base);
 
@@ -140,13 +144,13 @@ char *paseto_v2_local_encrypt(
 
 uint8_t *paseto_v2_local_decrypt(
         const char *encoded, size_t *message_len,
-        const v2_local_key key,
+        const struct paseto_v2_local_key *key,
         uint8_t **footer, size_t *footer_len) {
     if (!encoded || !message_len || !key) {
         errno = EINVAL;
         return NULL;
     }
-    if (key.header != V2_LOCAL) {
+    if (key->header != V2_LOCAL) {
         errno = EINVAL;
         return NULL;
     }
@@ -243,7 +247,7 @@ uint8_t *paseto_v2_local_decrypt(
             NULL,
             ct, ct_len,
             pa.base, pre_auth_len,
-            nonce, key.key_bytes) != 0) {
+            nonce, key->key_bytes) != 0) {
         free(decoded);
         free(pa.base);
         free(message);

--- a/src/paseto_v2_public.c
+++ b/src/paseto_v2_public.c
@@ -21,38 +21,46 @@ static const size_t signature_len = crypto_sign_BYTES;
 
 
 bool paseto_v2_public_load_public_key_hex(
-        uint8_t key[paseto_v2_PUBLIC_PUBLICKEYBYTES],
+        v2_public_pk key,
         const char *key_hex) {
-    return key_load_hex(key, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_hex);
+        key.header = V2_PUBLIC;
+    return key_load_hex(key.key_bytes, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_hex);
 }
 
 
 bool paseto_v2_public_load_public_key_base64(
-        uint8_t key[paseto_v2_PUBLIC_PUBLICKEYBYTES],
+        v2_public_pk key,
         const char *key_base64) {
-    return key_load_base64(key, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_base64);
+        key.header = V2_PUBLIC;
+    return key_load_base64(key.key_bytes, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_base64);
 }
 
 
 bool paseto_v2_public_load_secret_key_hex(
-        uint8_t key[paseto_v2_PUBLIC_SECRETKEYBYTES],
+        v2_public_sk key,
         const char *key_hex) {
-    return key_load_hex(key, paseto_v2_PUBLIC_SECRETKEYBYTES, key_hex);
+        key.header = V2_PUBLIC;
+    return key_load_hex(key.key_bytes, paseto_v2_PUBLIC_SECRETKEYBYTES, key_hex);
 }
 
 
 bool paseto_v2_public_load_secret_key_base64(
-        uint8_t key[paseto_v2_PUBLIC_SECRETKEYBYTES],
+        v2_public_sk key,
         const char *key_base64) {
-    return key_load_base64(key, paseto_v2_PUBLIC_SECRETKEYBYTES, key_base64);
+        key.header = V2_PUBLIC;
+    return key_load_base64(key.key_bytes, paseto_v2_PUBLIC_SECRETKEYBYTES, key_base64);
 }
 
 
 char *paseto_v2_public_sign(
         const uint8_t *message, size_t message_len,
-        const uint8_t key[paseto_v2_PUBLIC_SECRETKEYBYTES],
+        v2_public_sk key,
         const uint8_t *footer, size_t footer_len) {
     if (!message || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (key.header != V2_PUBLIC) {
         errno = EINVAL;
         return NULL;
     }
@@ -79,7 +87,7 @@ char *paseto_v2_public_sign(
     size_t pre_auth_len = pa.current - pa.base;
 
     uint8_t *ct = to_encode + message_len;
-    crypto_sign_detached(ct, NULL, pa.base, pre_auth_len, key);
+    crypto_sign_detached(ct, NULL, pa.base, pre_auth_len, key.key_bytes);
 
     free(pa.base);
 
@@ -124,9 +132,13 @@ char *paseto_v2_public_sign(
 
 uint8_t *paseto_v2_public_verify(
         const char *encoded, size_t *message_len,
-        const uint8_t key[paseto_v2_PUBLIC_PUBLICKEYBYTES],
+        const v2_public_pk key,
         uint8_t **footer, size_t *footer_len) {
     if (!encoded || !message_len || !key) {
+        errno = EINVAL;
+        return NULL;
+    }
+    if (key.header != V2_PUBLIC) {
         errno = EINVAL;
         return NULL;
     }
@@ -215,7 +227,7 @@ uint8_t *paseto_v2_public_verify(
         return NULL;
     }
     if (crypto_sign_verify_detached(
-            signature, pa.base, pre_auth_len, key) != 0) {
+            signature, pa.base, pre_auth_len, key.key_bytes) != 0) {
         free(decoded);
         free(decoded_footer);
         free(pa.base);

--- a/src/paseto_v2_public.c
+++ b/src/paseto_v2_public.c
@@ -21,46 +21,54 @@ static const size_t signature_len = crypto_sign_BYTES;
 
 
 bool paseto_v2_public_load_public_key_hex(
-        v2_public_pk key,
+        struct paseto_v2_public_pk *key,
         const char *key_hex) {
-        key.header = V2_PUBLIC;
-    return key_load_hex(key.key_bytes, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_hex);
+        struct paseto_v2_public_pk tmp;
+        *key = &tmp;
+        key->header = V2_PUBLIC;
+    return key_load_hex(key->key_bytes, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_hex);
 }
 
 
 bool paseto_v2_public_load_public_key_base64(
-        v2_public_pk key,
+        struct paseto_v2_public_pk *key,
         const char *key_base64) {
-        key.header = V2_PUBLIC;
-    return key_load_base64(key.key_bytes, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_base64);
+        struct paseto_v2_public_pk tmp;
+        *key = &tmp;
+        key->header = V2_PUBLIC;
+    return key_load_base64(key->key_bytes, paseto_v2_PUBLIC_PUBLICKEYBYTES, key_base64);
 }
 
 
 bool paseto_v2_public_load_secret_key_hex(
-        v2_public_sk key,
+        struct paseto_v2_public_sk key,
         const char *key_hex) {
-        key.header = V2_PUBLIC;
-    return key_load_hex(key.key_bytes, paseto_v2_PUBLIC_SECRETKEYBYTES, key_hex);
+        struct paseto_v2_public_sk tmp;
+        *key = &tmp;
+        key->header = V2_PUBLIC;
+    return key_load_hex(key->key_bytes, paseto_v2_PUBLIC_SECRETKEYBYTES, key_hex);
 }
 
 
 bool paseto_v2_public_load_secret_key_base64(
         v2_public_sk key,
         const char *key_base64) {
-        key.header = V2_PUBLIC;
-    return key_load_base64(key.key_bytes, paseto_v2_PUBLIC_SECRETKEYBYTES, key_base64);
+        struct paseto_v2_public_sk tmp;
+        *key = &tmp;
+        key->header = V2_PUBLIC;
+    return key_load_base64(key->key_bytes, paseto_v2_PUBLIC_SECRETKEYBYTES, key_base64);
 }
 
 
 char *paseto_v2_public_sign(
         const uint8_t *message, size_t message_len,
-        v2_public_sk key,
+        struct paseto_v2_public_sk *key,
         const uint8_t *footer, size_t footer_len) {
     if (!message || !key) {
         errno = EINVAL;
         return NULL;
     }
-    if (key.header != V2_PUBLIC) {
+    if (key->header != V2_PUBLIC) {
         errno = EINVAL;
         return NULL;
     }
@@ -87,7 +95,7 @@ char *paseto_v2_public_sign(
     size_t pre_auth_len = pa.current - pa.base;
 
     uint8_t *ct = to_encode + message_len;
-    crypto_sign_detached(ct, NULL, pa.base, pre_auth_len, key.key_bytes);
+    crypto_sign_detached(ct, NULL, pa.base, pre_auth_len, key->key_bytes);
 
     free(pa.base);
 
@@ -132,13 +140,13 @@ char *paseto_v2_public_sign(
 
 uint8_t *paseto_v2_public_verify(
         const char *encoded, size_t *message_len,
-        const v2_public_pk key,
+        const struct paseto_v2_public_pk *key,
         uint8_t **footer, size_t *footer_len) {
     if (!encoded || !message_len || !key) {
         errno = EINVAL;
         return NULL;
     }
-    if (key.header != V2_PUBLIC) {
+    if (key->header != V2_PUBLIC) {
         errno = EINVAL;
         return NULL;
     }
@@ -227,7 +235,7 @@ uint8_t *paseto_v2_public_verify(
         return NULL;
     }
     if (crypto_sign_verify_detached(
-            signature, pa.base, pre_auth_len, key.key_bytes) != 0) {
+            signature, pa.base, pre_auth_len, key->key_bytes) != 0) {
         free(decoded);
         free(decoded_footer);
         free(pa.base);


### PR DESCRIPTION
This wraps keys into a struct, which has a header flag. This flag is checked at runtime.

KeyHeader is an enum. The least significant bit holds purpose (Local = 0, Public = 1); the remaining are reserved for the version. This results in the following pattern:

- V1_LOCAL = 2
- V1_PUBLIC = 3
- V2_LOCAL = 4
- V2_PUBLIC = 5
- V3_LOCAL = 6
- V3_PUBLIC = 7
- V4_LOCAL = 8
- V4_PUBLIC = 9
- ...

See #7 